### PR TITLE
fixing bug that we cant iterate through items in place

### DIFF
--- a/src/simfish.py
+++ b/src/simfish.py
@@ -92,6 +92,7 @@ class Tank(object):
         return tally
 
     def remove_dead(self):
+        
         for coords, items in self._items.items():
             death_list = []
             for item in items:
@@ -183,7 +184,8 @@ class Tank(object):
         """ Iterate a single cycle of the items within the tank. Also
             provides random temperature variation.
         """
-        for coords, items in self._items.items():
+        fishies = self._items.copy()
+        for coords, items in fishies.items():
             for item in items:
                 item.turn(self)
         n = random.random()


### PR DESCRIPTION
For python 3, we get a bug when we try to iterate through the dictionary in place:

```python
# python simfish.py 
Traceback (most recent call last):
  File "simfish.py", line 549, in <module>
    curses.wrapper(main)
  File "/home/vanessa/anaconda3/lib/python3.5/curses/__init__.py", line 94, in wrapper
    return func(stdscr, *args, **kwds)
  File "simfish.py", line 546, in main
    tank.turn()
  File "simfish.py", line 186, in turn
    for coords, items in self._items.items():
```
so to fix this, I just make a copy of the dictionary first, and work from that.